### PR TITLE
Dev-3097 Pin Actions to Specific SHA

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,10 +10,10 @@ jobs:
     environment: prod
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92
         with:
           ruby-version: 2.7
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     environment: dev
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
 
       - name: Build Docker image
         run: docker build -t ruby .


### PR DESCRIPTION
Supply Chain Attacks - Poisoned Actions: Using Marketplace actions without pinning them to a specific commit SHA (e.g., using uses: actions/checkout@v4 instead of a unique hash). If a popular action creator's account is compromised, an attacker can push a malicious version that steals secrets (as seen in the famous tj-actions/changed-files incident).